### PR TITLE
Keeping default value null when user responsing other than yes or no.

### DIFF
--- a/api/models/ivr_prompt_mapping.py
+++ b/api/models/ivr_prompt_mapping.py
@@ -15,4 +15,4 @@ class IvrPromptMapping(TimestampMixin, db.Model):
     ivr_prompt_id = db.Column(db.Integer, db.ForeignKey("ivr_prompt.id"))
     mapped_table_name = db.Column(db.String(255))
     mapped_table_column_name = db.Column(db.String(255))
-    default_value = db.Column(db.String(255))
+    default_value = None

--- a/api/models/ivr_prompt_mapping.py
+++ b/api/models/ivr_prompt_mapping.py
@@ -15,4 +15,4 @@ class IvrPromptMapping(TimestampMixin, db.Model):
     ivr_prompt_id = db.Column(db.Integer, db.ForeignKey("ivr_prompt.id"))
     mapped_table_name = db.Column(db.String(255))
     mapped_table_column_name = db.Column(db.String(255))
-    default_value = None
+    default_value = db.Column(db.String(255))

--- a/api/services/prompt_service.py
+++ b/api/services/prompt_service.py
@@ -171,8 +171,7 @@ class PromptService(object):
                 setattr(class_object_data, column_name, prompt_response_value)
                 db.session.commit()
         except Exception as e:
-            print(e)
-            print("Exception occurred")
+            print(f"Exception occurred: {e}")
 
     def sanitize_keypress(self, data):
         keypress = data["keypress"]

--- a/api/services/prompt_service.py
+++ b/api/services/prompt_service.py
@@ -146,8 +146,13 @@ class PromptService(object):
                         prompt_response_value = True
                     elif prompt_response_value.upper() == "NO":
                         prompt_response_value = False
+                    else:
+                        prompt_response_value = None
 
-                if not prompt_response_value or prompt_response_value == "other":
+                elif (
+                    not prompt_response_value
+                    or prompt_response_value.lower() == "other"
+                ):
                     prompt_response_value = mapped_class.default_value
 
                 self.update_mapped_fields(
@@ -165,7 +170,8 @@ class PromptService(object):
             if class_object_data:
                 setattr(class_object_data, column_name, prompt_response_value)
                 db.session.commit()
-        except:
+        except Exception as e:
+            print(e)
             print("Exception occurred")
 
     def sanitize_keypress(self, data):


### PR DESCRIPTION
#299 

### Please complete the following steps and check these boxes before filing your PR:


### Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (a change which fixes an issue)
- [ ] New feature (a change which adds functionality)


### Short description of what this resolves:
<!--- Describe your changes in detail -->
Changed the IVR prompt response "Other" to null which is storing a non-bool value in bool type column.
<!--- Why these change required? What problem does it solve? -->
These changes are required not to store non-boolean data in the bool field. Now if the user responds "Other" for any IVR prompt then null value should store in the database.

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
- [x] The code follows the style guidelines of this project.
- [x] The code changes are passing the CI checks
- [ ] I have documented my code wherever required.
- [ ] The changes requires a change to the documentation.
- [ ] I have updated the documentation based on the my changes.
<!--- TODO: need to uncomment these two checklist once we start with test cases.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
-->
