### PR TITLE
Added functionality to mark user program unsub or complete or unsub using custom fields or groups.

### DIFF
--- a/api/services/contact_fields_mapping_service.py
+++ b/api/services/contact_fields_mapping_service.py
@@ -101,7 +101,8 @@ class ContactFieldsMappingService(object):
         try:
             table_data = table_object.get_by_user_id(user_details.id)
             if table_data:
-                setattr(table_data, column_name, mapped_table_column_value)
-                db.session.commit()
+                if table_data.status != mapped_table_column_value:
+                    setattr(table_data, column_name, mapped_table_column_value)
+                    db.session.commit()
         except Exception as e:
             print(f"Exception occurred: {e}")


### PR DESCRIPTION
Added functionality to mark user_program complete or Unsub using custom fields or groups.

#257 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->
<!-- Make sure the PR is against the `develop` branch -->

### Please complete the following steps and check these boxes before filing your PR:


### Types of changes
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (a change which fixes an issue)
- [ ] New feature (a change which adds functionality)


### Short description of what this resolves:
**Describe your changes in detail**
Added functionality to mark user_program unsub or complete using custom fields or groups in the `dry_flow`.
1. If the webhook payload contains the user group "Dost-unsub-users" then the user's latest in-progress program is marked as unsub.
2. If the webhook payload contains the user's custom field "Dost-program-completion"  as "completed" then the user's latest in-progress program is marked as complete.

**Why these change required? What problem does it solve?**
- Till now when user responds to the prompt that "Continue_to_listen_program" as "No" then the user is moved to the unsub group in the rapidpro from his/her current program_module_content group.
- Now the system is able to mark the user program as 'complete' and 'unsub' in the database also. 


### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have performed a self-review of my own code.
- [ ] The code follows the style guidelines of this project.
- [ ] The code changes are passing the CI checks
- [ ] I have documented my code wherever required.
- [ ] The changes requires a change to the documentation.
- [ ] I have updated the documentation based on the my changes.
<!--- TODO: need to uncomment these two checklist once we start with test cases.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
-->
