### PR TITLE
Don't generate error log when IVR prompt response is 'Other'

### DIFF
--- a/api/services/prompt_service.py
+++ b/api/services/prompt_service.py
@@ -44,11 +44,9 @@ class PromptService(object):
                             prompt_name, prompt_response
                         )
                     )
-                    if not ivr_prompt_details:
+                    if not ivr_prompt_details and prompt_response.lower() != "other":
                         logger.error(
-                            "IVR prompt not found for name '{}' and response '{}'".format(
-                                prompt_name, prompt_response
-                            )
+                            f"IVR prompt not found for name '{prompt_name}' and response '{prompt_response}'"
                         )
 
                     if ivr_prompt_details:


### PR DESCRIPTION
#351 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->
<!-- Make sure the PR is against the `develop` branch -->

### Please complete the following steps and check these boxes before filing your PR:


### Types of changes
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (a change which fixes an issue)
- [ ] New feature (a change which adds functionality)


### Short description of what this resolves:
**Describe your changes in detail**

**Earlier:**
After backfilling correct responses in RapidPro and Database there are some error logs still getting generated because of the "Other" as responses for any IVR Prompt name.

**Now:**
Now by these changes, if there is "Other" as a response in the webhook for any IVR Prompt then no error log should be get generated.

<!--- Why these change required? What problem does it solve? -->


### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
- [x] The code follows the style guidelines of this project.
- [x] The code changes are passing the CI checks
- [ ] I have documented my code wherever required.
- [ ] The changes requires a change to the documentation.
- [ ] I have updated the documentation based on the my changes.
<!--- TODO: need to uncomment these two checklist once we start with test cases.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
-->
